### PR TITLE
add 3d viewer, subheader, update wording

### DIFF
--- a/src/components/Acknowledgments.astro
+++ b/src/components/Acknowledgments.astro
@@ -4,7 +4,7 @@ const acknowledgments = [
   "NSF LSAMP: HRD-1826490",
   "Genentech Foundation Scholars #G-7874540",
   "NSF STC Center for Cellular Construction: DBI-1548297",
-  "Student Enrichment Opportunities (SEO)",
+  "Student Enrichment Opportunities (SEO) at SFSU",
   "Esquerra Lab",
 ];
 ---

--- a/src/components/DesignCard.astro
+++ b/src/components/DesignCard.astro
@@ -1,24 +1,35 @@
 ---
 const { data, url } = Astro.props;
+const glbPath = data.glbPath ?? null;
 ---
-<a href={url} class="group block rounded-2xl border p-4 hover:shadow-lg transition">
-  {data.cover && (
-    <img
-      src={data.cover}
-      alt={data.title}
-      class="rounded-xl mb-3"
-      loading="lazy"
-      decoding="async"
-    />
-  )}
-  <h3 class="font-semibold">{data.title}</h3>
-  {data.summary && <p class="text-sm text-zinc-600 mt-1">{data.summary}</p>}
-  {Array.isArray(data.tool) && data.tool.length > 0 && (
-    <div class="mt-3 flex flex-wrap gap-2">
-        {data.tool.map((t: string) => (
-        <span class="text-xs border rounded px-2 py-0.5">{t}</span>
-        ))}
-    </div>
-)}
 
-</a>
+<div class="group block rounded-2xl border p-4 hover:shadow-lg transition">
+  <!-- Not clickable -->
+  <div class="mb-3 rounded-xl overflow-hidden" style="width:100%;height:220px;">
+    <model-viewer
+      src={glbPath}
+      camera-controls
+      auto-rotate
+      interaction-prompt="none"
+      loading="lazy"
+      style="width:100%;height:100%;background:#f7f7f7;"
+    ></model-viewer>
+  </div>
+
+  <!-- Clickable section -->
+  <a href={url} class="block">
+    <h3 class="font-semibold">{data.title}</h3>
+
+    {data.summary && (
+      <p class="text-sm text-zinc-600 mt-1">{data.summary}</p>
+    )}
+
+    {Array.isArray(data.tool) && data.tool.length > 0 && (
+      <div class="mt-3 flex flex-wrap gap-2">
+        {data.tool.map((t: string) => (
+          <span class="text-xs border rounded px-2 py-0.5">{t}</span>
+        ))}
+      </div>
+    )}
+  </a>
+</div>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -30,8 +30,8 @@ const designs = defineCollection({
     summary: z.string().optional(),
     cover: z.string().optional(),
     thumbs: z.array(z.string()).optional(),
-    stl: z.boolean().default(false),
-    stlPath: z.string().optional(),
+    glb: z.boolean().default(false),
+    glbPath: z.string().optional(),
     links: z.object({
       source: z.string().url().optional(),
     }).optional(),

--- a/src/content/designs/flycam-v2-branded-mount-cover.md
+++ b/src/content/designs/flycam-v2-branded-mount-cover.md
@@ -4,8 +4,8 @@ date: "2025-08-11"
 tool: ["Shapr3D", "Figma"]
 summary: "A custom branded cover for FlyCam V2's mounting assembly."
 cover: "/images/flycam-v2-branded-mount-cover.webp" 
-stl: true
-stlPath: "/images/models/flycam-v2-branded-mount-cover.glb"
+glb: true
+glbPath: "/images/models/flycam-v2-branded-mount-cover.glb"
 ---
 ## Design Overview
 The branded mount cover adds aesthetic and protective value to the FlyCam V2 mount.

--- a/src/content/designs/flycam-v2-z-stop.md
+++ b/src/content/designs/flycam-v2-z-stop.md
@@ -4,8 +4,8 @@ date: "2025-08-11"
 tool: ["Shapr3D", "Fusion 360"]
 summary: "Mechanical hard stop that prevents the lens from crashing into the build plate."
 cover: "/images/flycam-v2-z-stop.webp"
-stl: true
-stlPath: "/images/models/flycam-v2-z-stop.glb"
+glb: true
+glbPath: "/images/models/flycam-v2-z-stop.glb"
 ---
 ## Design Overview
 The Z-stop is a physical end-stop that protects the camera and lens by limiting downward travel on the Z-axis. It ensures repeatable clearance so the optics can’t collide with the build plate during focusing or automated moves.

--- a/src/content/designs/stentorcam-camera-lens-holder.md
+++ b/src/content/designs/stentorcam-camera-lens-holder.md
@@ -4,8 +4,8 @@ date: "2024-07-01"
 tool: ["Shapr3D", "Fusion 360"]
 summary: "Mounts and stabilizes the camera and large lens for clear, consistent imaging."
 cover: "/images/stentorcam-v2/stentor-cam-v2-old-mount.webp"
-stl: true
-stlPath: "/images/models/stentorcam-v2-mount-black.glb"
+glb: true
+glbPath: "/images/models/stentorcam-v2-mount-black.glb"
 ---
 ## Design Overview
 This mount secures the camera and large lens assembly for StentorCam V2, providing the stability and alignment needed for high-quality imaging. The design minimizes vibration, keeps focus consistent, and makes camera installation straightforward.

--- a/src/content/designs/stentorcam-light-tray-casing.md
+++ b/src/content/designs/stentorcam-light-tray-casing.md
@@ -4,8 +4,8 @@ date: "2024-07-01"
 tool: ["Shapr3D", "Fusion 360"]
 summary: "Houses and aligns the IR light pad assembly for consistent, even illumination."
 cover: "/images/ir-light-pad/light-tray-bottom.webp"
-stl: true
-stlPath: "/images/models/stentorcam-light-tray-casing.glb"
+glb: true
+glbPath: "/images/models/stentorcam-light-tray-casing.glb"
 ---
 ## Design Overview
 This casing holds the IR light pad assembly, which consists of an acrylic sheet with diffusion film and IR LEDs wrapped along the edges. The enclosure ensures the components stay aligned, protected, and easy to service.

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -15,9 +15,11 @@ import Base from "@/layouts/Base.astro";
     <p class="text-zinc-700 mb-6">
       I’m a <strong>Computer Science and Biology</strong> major, researcher, and maker passionate about <strong>3D printing</strong>, 
       programming, and interdisciplinary innovation. My work combines bioengineering, computer science, 
-      and hardware development to create accessible technology for research and education. 
-      This past summer, I was a <strong>Software Engineering Intern at Fastly</strong> on the Cloud and Container 
-      Services Team, where I contributed to keeping the internet fast and safe.
+      and hardware development to create accessible technology for research and education.
+    </p>
+    <p class="text-zinc-700 mb-6">
+      As a <strong>Software Engineering Intern at Fastly</strong>, I worked on the Cloud and Container Services Team developing 
+      internal tooling and managing <strong>Kubernetes</strong> infrastructure to improve deployment reliability and policy compliance.
     </p>
 
     <div class="flex justify-center gap-3">

--- a/src/pages/community/index.astro
+++ b/src/pages/community/index.astro
@@ -6,7 +6,8 @@ const items = (await getCollection("community"))
   .sort((a,b)=> b.data.date.localeCompare(a.data.date));
 ---
 <Base title="Community & Events — Keith Curry">
-  <h1 class="text-2xl font-bold mb-6">Community & Events</h1>
+  <h1 class="text-2xl font-bold mb-2">Community & Events</h1>
+  <p class="text-zinc-500 text-sm mb-6">Catch up on events, talks, and community efforts</p>
   <div class="grid md:grid-cols-2 gap-6">
     {items.map(({ slug, data }) => <SimpleCard url={`/community/${slug}/`} data={data} />)}
   </div>

--- a/src/pages/designs/[slug].astro
+++ b/src/pages/designs/[slug].astro
@@ -59,11 +59,11 @@ const prettyDate = (iso?: string) =>
       </div>
     )}
 
-    {/* STL preview */}
-    {d.stl && d.stlPath && (
+    {/* GLB preview */}
+    {d.glb && d.glbPath && (
       <div class="my-6">
         <model-viewer
-          src={d.stlPath}
+          src={d.glbPath}
           camera-controls
           interaction-prompt="none"
           style="width:100%;height:520px;background:#f7f7f7;border-radius:1rem;"

--- a/src/pages/designs/index.astro
+++ b/src/pages/designs/index.astro
@@ -7,7 +7,8 @@ const designs = (await getCollection("designs"))
   .sort((a, b) => b.data.date.localeCompare(a.data.date));
 ---
 <Base title="Designs — Keith Curry">
-  <h1 class="text-2xl font-bold mb-6">Designs</h1>
+  <h1 class="text-2xl font-bold mb-2">Designs</h1>
+  <p class="text-zinc-500 text-sm mb-6">Interact with each model — drag to rotate • scroll to zoom</p>
   <div class="grid md:grid-cols-2 gap-6">
     {designs.map(({ slug, data }) => (
       <DesignCard url={`/designs/${slug}/`} data={data} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ const projects = (await getCollection("projects"))
   <section class="mb-10">
     <h1 class="text-3xl font-bold">Hi, I’m Keith.</h1>
     <p class="mt-2 max-w-2xl">
-      I like building and exploring ideas in software, imaging, and design.
+      I explore and prototype systems that combine design, imaging, and code.
     </p>
   </section>
   <section>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -6,7 +6,8 @@ const projects = (await getCollection("projects"))
   .sort((a,b)=> b.data.date.localeCompare(a.data.date));
 ---
 <Base title="Projects — Keith Curry">
-  <h1 class="text-2xl font-bold mb-6">Projects</h1>
+  <h1 class="text-2xl font-bold mb-2">Projects</h1>
+  <p class="text-zinc-500 text-sm mb-6">View project highlights, updates, and outcomes</p>
   <div class="grid md:grid-cols-2 gap-6">
     {projects.map(({ slug, data }) => (
       <ProjectCard url={`/projects/${slug}/`} data={data} />

--- a/src/pages/side-quests/index.astro
+++ b/src/pages/side-quests/index.astro
@@ -6,7 +6,8 @@ const items = (await getCollection("sidequests"))
   .sort((a,b)=> b.data.date.localeCompare(a.data.date));
 ---
 <Base title="Side Quests — Keith Curry">
-  <h1 class="text-2xl font-bold mb-6">Side Quests</h1>
+  <h1 class="text-2xl font-bold mb-2">Side Quests (Coming Soon)</h1>
+  <p class="text-zinc-500 text-sm mb-6">Personal builds, experiments, and fun projects</p>
   <div class="grid md:grid-cols-2 gap-6">
     {items.map(({ slug, data }) => <SimpleCard url={`/side-quests/${slug}/`} data={data} />)}
   </div>


### PR DESCRIPTION
### Summary

This PR adds a new 3D viewer component to the design cards, previously there was a static image preview.

Other changes:
- fix file name to reflect glb format instead of stl
- add subheaders to all pages, and instructions for 3d viewer
- split up paragraphs in about section, and reword

Fixes #5 
