### PR TITLE
normalize the canonical URLs and add SEO redirects

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import tailwind from '@astrojs/tailwind';
 export default defineConfig({
   site: 'https://keifh.com',
   output: 'static',
+  trailingSlash: 'never',
   integrations: [tailwind()],
   alias: { '@': './src' }
 });

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -4,14 +4,14 @@ import { siteMeta } from "@/lib/site";
 
 const staticRoutes = [
   "/",
-  "/about/",
-  "/contact/",
-  "/work/",
-  "/projects/",
-  "/designs/",
-  "/products/",
-  "/community/",
-  "/side-quests/",
+  "/about",
+  "/contact",
+  "/work",
+  "/projects",
+  "/designs",
+  "/products",
+  "/community",
+  "/side-quests",
 ];
 
 const escapeXml = (value: string) =>
@@ -35,23 +35,23 @@ export const GET: APIRoute = async ({ site }) => {
   const urls: Array<{ loc: string; lastmod?: string }> = [
     ...staticRoutes.map((path) => ({ loc: new URL(path, siteUrl).toString(), lastmod: undefined })),
     ...projects.map((entry) => ({
-      loc: new URL(`/projects/${entry.slug}/`, siteUrl).toString(),
+      loc: new URL(`/projects/${entry.slug}`, siteUrl).toString(),
       lastmod: entry.data.date,
     })),
     ...designs.map((entry) => ({
-      loc: new URL(`/designs/${entry.slug}/`, siteUrl).toString(),
+      loc: new URL(`/designs/${entry.slug}`, siteUrl).toString(),
       lastmod: entry.data.date,
     })),
     ...products.map((entry) => ({
-      loc: new URL(`/products/${entry.slug}/`, siteUrl).toString(),
+      loc: new URL(`/products/${entry.slug}`, siteUrl).toString(),
       lastmod: entry.data.date,
     })),
     ...community.map((entry) => ({
-      loc: new URL(`/community/${entry.slug}/`, siteUrl).toString(),
+      loc: new URL(`/community/${entry.slug}`, siteUrl).toString(),
       lastmod: entry.data.date,
     })),
     ...sidequests.map((entry) => ({
-      loc: new URL(`/side-quests/${entry.slug}/`, siteUrl).toString(),
+      loc: new URL(`/side-quests/${entry.slug}`, siteUrl).toString(),
       lastmod: entry.data.date,
     })),
   ];

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,27 @@
 {
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "www.keifh.com"
+        }
+      ],
+      "destination": "https://keifh.com/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/side-quests/tissue-microarray-silicone-mold",
+      "destination": "/products/moldiblocks",
+      "permanent": true
+    },
+    {
+      "source": "/side-quests/tissue-microarray-silicone-mold/",
+      "destination": "/products/moldiblocks",
+      "permanent": true
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
This pull request standardizes URL formats across the site by removing trailing slashes from routes and updates configuration to enforce this behavior. It also adds Vercel redirects for domain canonicalization and specific legacy URLs. These changes help ensure consistent URLs for SEO and user experience.

**URL Standardization:**

* Removed trailing slashes from all static and dynamic routes in the `sitemap.xml.ts` file, ensuring all URLs are generated without a trailing slash. [[1]](diffhunk://#diff-51ab18bf352d78986954e90aea56bbd16625c424e2eb78404c373780757751a6L7-R14) [[2]](diffhunk://#diff-51ab18bf352d78986954e90aea56bbd16625c424e2eb78404c373780757751a6L38-R54)
* Added `trailingSlash: 'never'` to the Astro configuration in `astro.config.mjs` to enforce no trailing slashes in generated site URLs.

**Redirects and Domain Canonicalization:**

* Added Vercel redirects in `vercel.json` to:
  - Redirect all traffic from `www.keifh.com` to `keifh.com` for domain canonicalization.
  - Redirect legacy `/side-quests/tissue-microarray-silicone-mold` URLs (with and without trailing slash) to the new `/products/moldiblocks` route.