### PR TITLE
set canonical site to www.

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
 
 export default defineConfig({
-  site: 'https://keifh.com',
+  site: 'https://www.keifh.com',
   output: 'static',
   trailingSlash: 'never',
   integrations: [tailwind()],


### PR DESCRIPTION
This pull request makes a minor update to the `astro.config.mjs` configuration file, updating the `site` URL to use the `www` subdomain.