### PR TITLE
fix mismatch with urls

### DIFF
--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,6 +1,6 @@
 export const siteMeta = {
   name: "Keith Curry",
-  url: "https://keifh.com",
+  url: "https://www.keifh.com",
   email: "kcurry@keifh.com",
   description:
     "Portfolio of Keith Curry, a builder working across imaging systems, research tools, 3D design, and software engineering.",

--- a/vercel.json
+++ b/vercel.json
@@ -1,17 +1,6 @@
 {
   "redirects": [
     {
-      "source": "/:path*",
-      "has": [
-        {
-          "type": "host",
-          "value": "www.keifh.com"
-        }
-      ],
-      "destination": "https://keifh.com/:path*",
-      "permanent": true
-    },
-    {
       "source": "/side-quests/tissue-microarray-silicone-mold",
       "destination": "/products/moldiblocks",
       "permanent": true


### PR DESCRIPTION
This pull request updates the site metadata and modifies the redirect configuration to better align with the intended domain structure. The most important changes are:

Domain and Site Metadata Updates:

* Changed the `url` property in `siteMeta` (in `src/lib/site.ts`) from `https://keifh.com` to `https://www.keifh.com` to reflect the preferred canonical domain.

Redirect Configuration Changes:

* Removed the redirect rule in `vercel.json` that previously redirected all requests from `www.keifh.com` to `keifh.com`, allowing both domains to be served independently or prioritizing `www.keifh.com` as the main domain.